### PR TITLE
Fix deprecation warning

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -9,4 +9,7 @@ Spree::Backend::Config.configure do |config|
   )
 end
 
-MIME::Types.add(MIME::Type.new(["application/csv", "csv"]), true)
+MIME::Types.add(
+  MIME::Type.new("content-type" => "application/csv", "extensions" => ["csv"]),
+  true
+)


### PR DESCRIPTION
Previously we were seeing `MIME::Type.MIME::Type.new when called with an Array is deprecated.`

ref ENG-10666